### PR TITLE
add ianconsolata as an org member

### DIFF
--- a/github/pl-strflt.yml
+++ b/github/pl-strflt.yml
@@ -5,6 +5,8 @@ members:
     - galargh
     - laurentsenta
     - tinytb
+  member:
+    - ianconsolata
 repositories:
   .github-from-galorgh:
     allow_auto_merge: false


### PR DESCRIPTION
### Summary
Adds https://github.com/ianconsolata as an org member.

### Why do you need this?
To be able to make Ian app manager for https://github.com/apps/pl-strflt-tf-aws-gh-observability. Maybe we could use the App for github exporters. 

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->
n/a

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

